### PR TITLE
feat: use `linux-virt` alpine kernel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,4 @@ qemu/filesystem.qcow2
 qemu/filesystem-diff.qcow2
 qemu/filesystem-large.qcow2
 qemu/qemu.pid
-
+boot/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,8 @@
 FROM alpine:latest@sha256:a8560b36e8b8210634f77d9f7f9efd7ffa463e380b75e2e74aff4511df3ef88c
 
 RUN apk update \
+    # kernel 
+    && apk add linux-virt \
     # autologin
     && apk add agetty \ 
     # init system (used for networking)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,12 @@
 # inspired by https://github.com/k8spacket/k8spacket/blob/master/tests/e2e/vm/filesystem/Dockerfile
 
 FROM alpine:latest@sha256:a8560b36e8b8210634f77d9f7f9efd7ffa463e380b75e2e74aff4511df3ef88c
-
-RUN apk update \
-    # kernel 
-    && apk add linux-virt \
-    # autologin
-    && apk add agetty \ 
-    # init system (used for networking)
-    && apk add openrc
+ARG FLAVOR
+RUN apk update
+# kernel, autologin, init system (used for networking)
+RUN apk add linux-${FLAVOR} agetty openrc
+# debug stuff, in a new layer to avoid unnecessary rebuilds
+RUN apk add 
 
 # enable serial port for login
 RUN echo "ttyS0::respawn:/sbin/agetty --autologin root ttyS0 vt100\n" >> /etc/inittab

--- a/Makefile
+++ b/Makefile
@@ -2,12 +2,14 @@
 
 SU_DOCKER=$(shell id -nGz "${USER}" | grep -qzxF "docker" || echo sudo)
 SU_LVIRTD=$(shell id -nGz "${USER}" | grep -qzxF "libvirtd" || echo sudo)
+# needs to correspond to the linux-$FLAVOR in the dockerfile
+FLAVOR=virt
 
 qemu/filesystem.qcow2: Dockerfile
 	# build filesystem image and store as tar archive
-	DOCKER_BUILDKIT=1 ${SU_DOCKER} docker build --output "type=tar,dest=qemu/filesystem.tar" .
+	DOCKER_BUILDKIT=1 ${SU_DOCKER} docker build --build-arg FLAVOR=${FLAVOR} --output "type=tar,dest=qemu/filesystem.tar" .
 	# extract kernel
-	tar --extract --file=qemu/filesystem.tar boot/vmlinuz-virt boot/initramfs-virt
+	tar --extract --file=qemu/filesystem.tar boot/vmlinuz-${FLAVOR} boot/initramfs-${FLAVOR} boot/config-6.12.25-0-${FLAVOR}
 	# convert tar to qcow2 image
 	${SU_LVIRTD} virt-make-fs --partition --type=ext4 --format=qcow2 --size=+100M qemu/filesystem.tar qemu/filesystem.qcow2
 
@@ -18,13 +20,15 @@ build:
 all: qemu
 
 qemu: build qemu/filesystem.qcow2
+	# we need an initramfs because alpine loads all filesystem drivers as modules
 	${SU_LVIRTD} qemu-system-x86_64 \
 		-cpu host \
 		-m 4G \
 		-smp 4 \
-		-kernel ./boot/vmlinuz-virt \
-		-initrd ./boot/initramfs-virt \
-		-append "rootfstype=ext4 modules=ext4 console=ttyS0 root=/dev/sda1 rw" \
+		-nic user,model=virtio-net-pci \
+		-kernel ./boot/vmlinuz-${FLAVOR} \
+		-initrd ./boot/initramfs-${FLAVOR} \
+		-append "rootfstype=ext4 console=ttyS0 root=/dev/sda1 rw" \
 		-hda ./qemu/filesystem.qcow2 \
 		-enable-kvm \
 		-pidfile ./qemu/qemu.pid \

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ qemu/filesystem.qcow2: Dockerfile
 	# extract kernel
 	tar --extract --file=qemu/filesystem.tar boot/vmlinuz-virt boot/initramfs-virt
 	# convert tar to qcow2 image
-	${SU_LVIRTD} virt-make-fs --format=qcow2 --size=+100M qemu/filesystem.tar qemu/filesystem-large.qcow2
+	${SU_LVIRTD} virt-make-fs --partition --format=qcow2 --size=+100M qemu/filesystem.tar qemu/filesystem-large.qcow2
 	# reduce size of image
 	qemu-img convert qemu/filesystem-large.qcow2 -O qcow2 qemu/filesystem.qcow2
 
@@ -26,10 +26,10 @@ qemu: build qemu/filesystem.qcow2
 		-cpu host \
 		-m 4G \
 		-smp 4 \
-		-kernel ./boot/vmlinuz-virt
-		-initrd ./boot/initramfs-virt
-		-append "console=ttyS0 root=/dev/sda rw" \
-		-drive file="./qemu/filesystem-diff.qcow2,format=qcow2" \
+		-kernel ./boot/vmlinuz-virt \
+		-initrd ./boot/initramfs-virt \
+		-append "rootfstype=ext4 modules=ext4 console=ttyS0 root=/dev/sda1 rw" \
+		-hda ./qemu/filesystem-diff.qcow2 \
 		-enable-kvm \
 		-pidfile ./qemu/qemu.pid \
 		-nographic

--- a/Makefile
+++ b/Makefile
@@ -9,9 +9,7 @@ qemu/filesystem.qcow2: Dockerfile
 	# extract kernel
 	tar --extract --file=qemu/filesystem.tar boot/vmlinuz-virt boot/initramfs-virt
 	# convert tar to qcow2 image
-	${SU_LVIRTD} virt-make-fs --partition --format=qcow2 --size=+100M qemu/filesystem.tar qemu/filesystem-large.qcow2
-	# reduce size of image
-	qemu-img convert qemu/filesystem-large.qcow2 -O qcow2 qemu/filesystem.qcow2
+	${SU_LVIRTD} virt-make-fs --partition --type=ext4 --format=qcow2 --size=+100M qemu/filesystem.tar qemu/filesystem.qcow2
 
 build:
 	mkdir -p build
@@ -20,8 +18,6 @@ build:
 all: qemu
 
 qemu: build qemu/filesystem.qcow2
-	rm -f qemu/filesystem-diff.qcow2
-	${SU_LVIRTD} qemu-img create -f qcow2 -b filesystem.qcow2 -F qcow2 qemu/filesystem-diff.qcow2
 	${SU_LVIRTD} qemu-system-x86_64 \
 		-cpu host \
 		-m 4G \
@@ -29,7 +25,7 @@ qemu: build qemu/filesystem.qcow2
 		-kernel ./boot/vmlinuz-virt \
 		-initrd ./boot/initramfs-virt \
 		-append "rootfstype=ext4 modules=ext4 console=ttyS0 root=/dev/sda1 rw" \
-		-hda ./qemu/filesystem-diff.qcow2 \
+		-hda ./qemu/filesystem.qcow2 \
 		-enable-kvm \
 		-pidfile ./qemu/qemu.pid \
 		-nographic


### PR DESCRIPTION
- use ext4 as filesystem (others should work too)
- use initramfs because all alpine file system drivers are there
- enable virtio networking (alpine seems to require this)
- remove unnecessary steps when preparing the file system