### PR TITLE
Basic rate limiting using atomics

### DIFF
--- a/src/bc-pqp-ebpf-kernel.c
+++ b/src/bc-pqp-ebpf-kernel.c
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-#include "stdlib.h"
 #include <linux/bpf.h>
 #include <linux/if_ether.h>
 #include <linux/types.h>

--- a/src/bc-pqp-ebpf-kernel.c
+++ b/src/bc-pqp-ebpf-kernel.c
@@ -57,7 +57,7 @@ static __u64 try_increment_counter(
     __sync_fetch_and_add(&queue_read->counter, increment);
     __u64 new_counter = queue_read->counter;
     bpf_trace_printk(
-        "Packet counters: QUEUE: %u, COUNTER: %u, TIME: %u", 50, key,
+        "Packet counters: QUEUE: %u, COUNTER: %u, TIME: %lu", 51, key,
         new_counter, last_refresh
     );
     if (new_counter < RATE) {


### PR DESCRIPTION
Note: because `__sync_fetch_and_add` does not return the previous value as specified (https://github.com/llvm/llvm-project/issues/35921), we can't count the packets atomically. To do this correctly we would either have to use compare and swap or a spin lock, both of which would probably perform badly.