### PR TITLE
Fluent TBF/PQP

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,15 @@ $(EBPF_OBJ): $(BUILD_DIR)/%.o: $(SRC_DIR)/%.c
 	    -emit-llvm -g \
 		-o $(@:.o=.ll) $<
 	$(LLC) -march=bpf -filetype=obj -o $@ $(@:.o=.ll)
+	$(CLANG) -S \
+	    -target bpf \
+	    -D __BPF_TRACING__ \
+		-D DEBUG \
+		$(C_FLAGS) \
+	    $(WARN_FLAGS) \
+	    -emit-llvm -g \
+		-o debug_$(@:.o=.ll) $<
+	$(LLC) -march=bpf -filetype=obj -o debug_$@ debug_$(@:.o=.ll)
 
 # === BUILDING THE VIRTUAL MACHINE ===
 

--- a/src/bc-pqp-ebpf-kernel.c
+++ b/src/bc-pqp-ebpf-kernel.c
@@ -70,9 +70,11 @@ const char* const classification_names[UNCLASSIFIED + 1] = {
     [UNCLASSIFIED] = "Unclassified",
 };
 
-static __s64 calculate_drain(__u64 now, __u64 previous, __u64 rate) {
-    // todo is this always positive?
+static __u64 calculate_drain(__u64 now, __u64 previous, __u64 rate) {
     __s64 timespan = now - previous;
+    if (timespan < (__s64)0) {
+        return 0;
+    }
     return (timespan * rate) / ONE_SECOND;
 }
 
@@ -82,7 +84,7 @@ static __u64 try_increment_counter(
     __u64 now = bpf_ktime_get_ns();
     __u64 last_packet = queue->last_packet;
     __u64 rate = queue->rate;
-    __s64 drain = calculate_drain(now, last_packet, rate);
+    __u64 drain = calculate_drain(now, last_packet, rate);
     __u64 prev = __sync_val_compare_and_swap(
         &queue->last_packet, last_packet, now
     );

--- a/src/bc-pqp-ebpf-kernel.c
+++ b/src/bc-pqp-ebpf-kernel.c
@@ -14,6 +14,8 @@
 
 #define ONE_SECOND 1000000000L // 1s = 1e9 ns
 #define RATE 1e6               // 1 MB/s
+#define MAX_TIMESPAN                                                           \
+    ((1 << 64) / RATE) // limit timespan to prevent integer overflow
 
 struct phantom_queue {
     // how many bytes are currently in this queue
@@ -75,6 +77,10 @@ static __u64 calculate_drain(__u64 now, __u64 previous, __u64 rate) {
     if (timespan < (__s64)0) {
         return 0;
     }
+    if (timespan >= (__s64)MAX_TIMESPAN) {
+        // TODO: find a (better) way to detect integer overflow
+        return (1 << 64) - 1;
+    }
     return (timespan * rate) / ONE_SECOND;
 }
 
@@ -103,28 +109,22 @@ static __u64 try_increment_counter(
     bpf_trace_printk("occ: %li, pkt: %lu", 19, occupancy, packet_size);
     bpf_trace_printk("drain: %li, diff: %li", 22, drain, diff);
 
+    __u64 rv = 0;
 
-    if (diff > (__s64)0) {
-        // now we are can write to the occupancy, but we still need to check
-        // whether it fits into our capacity
-        if (occupancy + diff <= (__s64)queue->capacity) {
-            __sync_fetch_and_add(&queue->occupancy, diff);
-            bpf_trace_printk("counter increment: success", 27);
-            return 0;
-        }
-        bpf_trace_printk("counter increment: failure", 27);
-    } else {
-        // we drain from the occupancy until it is empty
-        if (occupancy + diff < (__s64)0) {
-            __sync_fetch_and_sub(&queue->occupancy, occupancy);
-        } else {
-            __sync_fetch_and_add(&queue->occupancy, diff);
-        }
+    if (occupancy + diff <= (__s64)queue->capacity) {
         bpf_trace_printk("counter increment: success", 27);
-        return 0;
+    } else {
+        diff = -drain;
+        bpf_trace_printk("counter increment: failure", 27);
+        rv = 1;
     }
-
-    return 1;
+    // we drain from the occupancy until it is empty
+    if (occupancy + diff < (__s64)0) {
+        __sync_fetch_and_sub(&queue->occupancy, occupancy);
+    } else {
+        __sync_fetch_and_add(&queue->occupancy, diff);
+    }
+    return rv;
 }
 
 // classify packet using 8-bit DiffServ value from IP's TOS header field

--- a/src/bc-pqp-ebpf-kernel.c
+++ b/src/bc-pqp-ebpf-kernel.c
@@ -17,7 +17,6 @@
 #define ONE_SECOND 1000000000L // 1s = 1e9 ns
 #define RATE 1e6               // 1 MB/s
 
-#define DEBUG
 #ifdef DEBUG
 #define log(...) bpf_trace_printk(__VA_ARGS__)
 #else


### PR DESCRIPTION
This PR implements PQP, the token bucket filter, in a "fluent" way.
More specifically, we decrement the phantom queues' occupancies on each incoming packet by a small amount relative to the passed time since the last decrement.
Before, we decremented the occupancies at fixed intervals (e.g. each second).