### PR TITLE
feat: improve accuracy of counted packets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ ARG FLAVOR
 
 # kernel, autologin, init system (used for networking), network tools
 RUN apk add linux-${FLAVOR} agetty openrc xdp-tools iproute2 iputils-ping tcpdump ethtool bash
-RUN apk add hping3 --update-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing
+RUN apk add hping3 --update-cache --repository https://dl-cdn.alpinelinux.org/alpine/edge/testing
 # debug stuff, in a new layer to avoid unnecessary rebuilds
 RUN apk add 
 

--- a/Makefile
+++ b/Makefile
@@ -44,13 +44,14 @@ $(EBPF_OBJ): $(BUILD_DIR)/%.o: $(SRC_DIR)/%.c
 
 # === BUILDING THE VIRTUAL MACHINE ===
 
-SU_DOCKER=$(shell id -nGz "${USER}" | grep -qzxF "docker" || echo sudo)
+SU_DOCKER=$(shell id -nGz "${USER}" | grep -qzxF "docker" || type podman > /dev/null || echo sudo)
 SU_LVIRTD=$(shell id -nGz "${USER}" | grep -qzxF "libvirtd" || echo sudo)
+CNTNR_CMD=$(shell type podman > /dev/null && echo podman || echo docker)
 FLAVOR=virt
 
 qemu/filesystem.qcow2: Dockerfile $(EBF_OBJ) 
 	# build filesystem image and store as tar archive
-	DOCKER_BUILDKIT=1 ${SU_DOCKER} docker build --build-arg FLAVOR=${FLAVOR} --output "type=tar,dest=qemu/filesystem.tar" .
+	DOCKER_BUILDKIT=1 ${SU_DOCKER} ${CNTNR_CMD} build --build-arg FLAVOR=${FLAVOR} --output "type=tar,dest=qemu/filesystem.tar" .
 	# extract kernel
 	tar --extract --file=qemu/filesystem.tar --wildcards "boot/*"
 	# convert tar to qcow2 image

--- a/src/bc-pqp-ebpf-kernel.c
+++ b/src/bc-pqp-ebpf-kernel.c
@@ -14,9 +14,12 @@
 #define RX_QUEUES 4
 #define PHANTOM_QUEUES 10
 
+#define MEBIBYTE (1 << 20)
+#define GIBIBYTE (1 << 30)
+
 #define ONE_SECOND 1000000000L // 1s = 1e9 ns
 #define BURST_TIME 100000000L
-#define RATE 1e6 // 1 MB/s
+#define RATE MEBIBYTE // 1 MB/s
 
 #ifdef DEBUG
 #define log(...) bpf_trace_printk(__VA_ARGS__)
@@ -243,8 +246,32 @@ static enum packet_classification classify_packet(struct xdp_md* ctx) {
     }
 }
 
-static __u32 calculate_size(struct xdp_md* ctx) {
-    return ctx->data_end - ctx->data;
+static __u32 calculate_size(
+    struct xdp_md* ctx, enum packet_classification classification
+) {
+    __u32 full_size = ctx->data_end - ctx->data;
+    __u32 ipv4_size = 20;
+    switch (classification) {
+        case IPv6:
+            // todo distinguish UDP/TCP/ICMP
+            return full_size - 40;
+        case IPv4_ICMP:
+            return full_size - ipv4_size - 8;
+        case IPv4_UDP_0x00_TOS:
+        case IPv4_UDP_0x20_TOS:
+        case IPv4_UDP_0xb8_TOS:
+            // we don't consider packets with an options field
+            return full_size - ipv4_size - 8;
+        case IPv4_TCP_0x00_TOS:
+        case IPv4_TCP_0x20_TOS:
+        case IPv4_TCP_0xa0_TOS:
+        case IPv4_TCP_0xb8_TOS:
+            // we don't consider packets with an options field
+            return full_size - ipv4_size - 20;
+        case UNCLASSIFIED:
+        default:
+            return full_size;
+    }
 }
 
 static __u32 initialize(struct phantom_queue* queue) {
@@ -266,7 +293,7 @@ int bc_pqp_xdp(struct xdp_md* ctx) {
         __sync_fetch_and_add(&classification_counts[key], 1);
     }
 
-    __u64 packet_size = calculate_size(ctx);
+    __u64 packet_size = calculate_size(ctx, classification);
     struct phantom_queue* queue = (struct phantom_queue*)bpf_map_lookup_elem(
         &xdp_general_map, &key
     );

--- a/src/bc-pqp-ebpf-kernel.c
+++ b/src/bc-pqp-ebpf-kernel.c
@@ -24,7 +24,11 @@
 #define STRIP_HEADERS
 
 #ifdef DEBUG
-#define log(...) bpf_trace_printk(__VA_ARGS__)
+#define log(fmt, ...)                                                          \
+    ({                                                                         \
+        char ____fmt[] = fmt;                                                  \
+        bpf_trace_printk(____fmt, sizeof(____fmt), ##__VA_ARGS__);             \
+    })
 #else
 #define log(...)                                                               \
     do {                                                                       \
@@ -121,7 +125,7 @@ static void burst_control(__u32 key, struct phantom_queue* queue) {
             if (res == 0) {
                 // race won, add magic
                 __sync_fetch_and_add(&queue->occupancy, magic);
-                log("added %ld magic bytes to queue %d with occupancy %ld", 53,
+                log("added %ld magic bytes to queue %d with occupancy %ld",
                     magic, key, occupancy);
             }
         }
@@ -138,7 +142,7 @@ static void burst_control(__u32 key, struct phantom_queue* queue) {
                 __sync_fetch_and_sub(&queue->occupancy, magic);
                 log("subtracted %ld magic bytes from queue %d with occupancy "
                     "%ld",
-                    60, magic, key, occupancy);
+                    magic, key, occupancy);
             }
         }
     }
@@ -170,10 +174,10 @@ static __u64 try_increment_counter(
     if (occupancy + diff + ((__s64)packet_size) <= (__s64)queue->capacity) {
         diff += packet_size;
         rv = 0;
-        log("counter increment: success", 27);
+        log("counter increment: success");
     } else {
         rv = 1;
-        log("counter increment: failure", 27);
+        log("counter increment: failure");
     }
     // check lower bound
     if (occupancy + diff > 0) {
@@ -181,8 +185,8 @@ static __u64 try_increment_counter(
     } else if (occupancy > 0) {
         __sync_fetch_and_sub(&queue->occupancy, occupancy);
     }
-    log("occ: %li, pkt: %lu", 19, occupancy, packet_size);
-    log("drain: %li, diff: %li", 22, drain, diff);
+    log("occ: %li, pkt: %lu", occupancy, packet_size);
+    log("drain: %li, diff: %li", drain, diff);
 
     return rv;
 }
@@ -290,7 +294,7 @@ static __u32 initialize(struct phantom_queue* queue) {
 
 SEC("xdp")
 int bc_pqp_xdp(struct xdp_md* ctx) {
-    log("===== BC-PQP on rx-queue %u =====", 34, ctx->rx_queue_index);
+    log("===== BC-PQP on rx-queue %u =====", ctx->rx_queue_index);
 
     enum packet_classification classification = classify_packet(ctx);
     __u32 key = UNCLASSIFIED;
@@ -304,7 +308,7 @@ int bc_pqp_xdp(struct xdp_md* ctx) {
         &xdp_general_map, &key
     );
     if (queue == NULL) {
-        log("Could not read element %u from map", 35, key);
+        log("Could not read element %u from map", key);
         goto abort;
     } else {
         if (queue->capacity == 0) {
@@ -314,7 +318,7 @@ int bc_pqp_xdp(struct xdp_md* ctx) {
                 // race won, we can initialize our queue
                 res = initialize(queue);
                 if (res) {
-                    log("failed to initialize queue %u", 30, key);
+                    log("failed to initialize queue %u", key);
                     goto abort;
                 }
             }
@@ -328,13 +332,13 @@ int bc_pqp_xdp(struct xdp_md* ctx) {
         }
     }
 abort:
-    log("We are aborting", 16);
+    log("We are aborting");
     return XDP_ABORTED;
 drop:
-    log("We are dropping the packet.", 28);
+    log("We are dropping the packet.");
     return XDP_DROP;
 pass:
-    log("We are passing the packet to the kernel.", 41);
+    log("We are passing the packet to the kernel.");
     return XDP_PASS;
 }
 

--- a/src/bc-pqp-ebpf-kernel.c
+++ b/src/bc-pqp-ebpf-kernel.c
@@ -21,6 +21,8 @@
 #define BURST_TIME 100000000L
 #define RATE MEBIBYTE // 1 MB/s
 
+#define STRIP_HEADERS
+
 #ifdef DEBUG
 #define log(...) bpf_trace_printk(__VA_ARGS__)
 #else
@@ -250,6 +252,9 @@ static __u32 calculate_size(
     struct xdp_md* ctx, enum packet_classification classification
 ) {
     __u32 full_size = ctx->data_end - ctx->data;
+#ifndef STRIP_HEADERS
+    return full_size;
+#else
     __u32 ipv4_size = 20;
     switch (classification) {
         case IPv6:
@@ -272,6 +277,7 @@ static __u32 calculate_size(
         default:
             return full_size;
     }
+#endif
 }
 
 static __u32 initialize(struct phantom_queue* queue) {

--- a/src/bc-pqp-ebpf-kernel.c
+++ b/src/bc-pqp-ebpf-kernel.c
@@ -25,10 +25,10 @@
 
 #ifdef DEBUG
 #define log(fmt, ...)                                                          \
-    ({                                                                         \
+    (do {                                                                      \
         char ____fmt[] = fmt;                                                  \
         bpf_trace_printk(____fmt, sizeof(____fmt), ##__VA_ARGS__);             \
-    })
+    } while (0))
 #else
 #define log(...)                                                               \
     do {                                                                       \


### PR DESCRIPTION
- only count packet data, not headers 
  - for now we only really support the traffic that we classify, so IPv4. Extending this to IPv6 would be trivial, but since we only generate IPv4 traffic this should suffice
- count in base-2 units (i.e Mebibyte, Kibibyte) instead of base-10 ones (i.e. Megabyte, Kilobyte)

If we limit to 1 Mebibyte of traffic in the `simple_test` suite, these are the results on the server:

```
-----------------------------------------------------------
Server listening on 5201 (test #1)
-----------------------------------------------------------
Accepted connection from 192.168.101.10, port 39420
[  5] local 192.168.102.10 port 5201 connected to 192.168.101.10 port 60434
[ ID] Interval           Transfer     Bitrate         Jitter    Lost/Total Datagrams
[  5]   0.00-1.00   sec  1.11 MBytes  9.31 Mbits/sec  0.021 ms  63437/64241 (99%)  
[  5]   1.00-2.00   sec   984 KBytes  8.06 Mbits/sec  0.020 ms  65097/65793 (99%)  
[  5]   2.00-3.00   sec   984 KBytes  8.06 Mbits/sec  0.023 ms  63939/64635 (99%)  
[  5]   3.00-4.00   sec   983 KBytes  8.05 Mbits/sec  0.017 ms  65434/66129 (99%)  
[  5]   4.00-5.00   sec   981 KBytes  8.04 Mbits/sec  0.021 ms  71824/72518 (99%)  
[  5]   5.00-6.00   sec   980 KBytes  8.03 Mbits/sec  0.016 ms  71193/71886 (99%)  
[  5]   6.00-7.00   sec   980 KBytes  8.02 Mbits/sec  0.019 ms  72205/72898 (99%)  
[  5]   7.00-8.00   sec   979 KBytes  8.02 Mbits/sec  0.017 ms  72655/73347 (99%)  
[  5]   8.00-9.00   sec   980 KBytes  8.03 Mbits/sec  0.021 ms  71500/72193 (99%)  
[  5]   9.00-10.00  sec   980 KBytes  8.03 Mbits/sec  0.014 ms  69796/70489 (99%)  
[  5]  10.00-10.00  sec  1.41 KBytes  6.27 Mbits/sec  0.019 ms  82/83 (99%)  
- - - - - - - - - - - - - - - - - - - - - - - - -
[ ID] Interval           Transfer     Bitrate         Jitter    Lost/Total Datagrams
[  5]   0.00-10.00  sec  9.74 MBytes  8.17 Mbits/sec  0.019 ms  687162/694212 (99%)  receiver
```
... which is close enough I think.