### PR TITLE
Kernel Bypass

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ FROM alpine:${ALPINE_REVISION}
 ARG FLAVOR
 
 # kernel, autologin, init system (used for networking), network tools
-RUN apk add linux-${FLAVOR} agetty openrc xdp-tools iproute2 iputils-ping tcpdump ethtool bash
+RUN apk add linux-${FLAVOR} agetty openrc xdp-tools iproute2 iputils-ping tcpdump ethtool bash bpftool
 RUN apk add hping3 --update-cache --repository https://dl-cdn.alpinelinux.org/alpine/edge/testing
 # debug stuff, in a new layer to avoid unnecessary rebuilds
 RUN apk add 

--- a/scripts/load.sh
+++ b/scripts/load.sh
@@ -6,9 +6,13 @@ else
     f=$1
 fi
 
+echo "Loading eBPF program $f"
 # timers need a userspace reference to work (thats why we use --pin-path)
 # see https://docs.ebpf.io/linux/helper-function/bpf_timer_init/
 xdp-loader load --pin-path /sys/fs/bpf/bc-pqp -m skb eth0 $f || exit 1
+
+echo "Resolving MAC addresses and writing them to eBPF map:"
+echo "If routes are not established, the MAC resolution might take a few seconds..."
 
 ping -c1 192.168.101.10 &> /dev/null
 ping -c1 192.168.102.10 &> /dev/null

--- a/scripts/load.sh
+++ b/scripts/load.sh
@@ -1,5 +1,43 @@
-#!/bin/sh
+#!/bin/bash
+
+if [ $# -eq 0 ]; then
+    f=bc-pqp-ebpf-kernel.o
+else
+    f=$1
+fi
 
 # timers need a userspace reference to work (thats why we use --pin-path)
 # see https://docs.ebpf.io/linux/helper-function/bpf_timer_init/
-xdp-loader load --pin-path /sys/fs/bpf/bc-pqp -m skb eth0 bc-pqp-ebpf-kernel.o
+xdp-loader load --pin-path /sys/fs/bpf/bc-pqp -m skb eth0 $f || exit 1
+
+ping -c1 192.168.101.10 &> /dev/null
+ping -c1 192.168.102.10 &> /dev/null
+
+VM_INGRESS_MAC=$(ip link show eth0 | awk '/ether/ {print $2}')
+VM_EGRESS_MAC=$(ip link show eth1 | awk '/ether/ {print $2}')
+
+CLIENT_MAC=$(ip neigh show 192.168.101.10 | awk '{print $5}')
+SERVER_MAC=$(ip neigh show 192.168.102.10 | awk '{print $5}')
+
+echo "VM_INGRESS_MAC = $VM_INGRESS_MAC"
+echo "VM_EGRESS_MAC = $VM_EGRESS_MAC"
+echo "CLIENT_MAC = $CLIENT_MAC"
+echo "SERVER_MAC = $SERVER_MAC"
+
+mac2hex() {
+    IFS=":" read -ra octets <<< "$1"
+    printf "%02x %02x %02x %02x %02x %02x 00 00" "0x${octets[0]}" "0x${octets[1]}" "0x${octets[2]}" \
+        "0x${octets[3]}" "0x${octets[4]}" "0x${octets[5]}"
+}
+
+HEX_VM_INGRESS_MAC=$(mac2hex $VM_INGRESS_MAC)
+HEX_VM_EGRESS_MAC=$(mac2hex $VM_EGRESS_MAC)
+HEX_CLIENT_MAC=$(mac2hex $CLIENT_MAC)
+HEX_SERVER_MAC=$(mac2hex $SERVER_MAC)
+
+MAP_PATH="/sys/fs/bpf/bc-pqp/mac_map"
+
+bpftool map update pinned $MAP_PATH key 0 0 0 0 value hex $HEX_CLIENT_MAC
+bpftool map update pinned $MAP_PATH key 1 0 0 0 value hex $HEX_VM_INGRESS_MAC
+bpftool map update pinned $MAP_PATH key 2 0 0 0 value hex $HEX_VM_EGRESS_MAC
+bpftool map update pinned $MAP_PATH key 3 0 0 0 value hex $HEX_SERVER_MAC

--- a/scripts/net.sh
+++ b/scripts/net.sh
@@ -19,6 +19,7 @@ SERVER_VM_IF="eth1"
 CLIENT_VM_IP=192.168.101.100
 SERVER_VM_IP=192.168.102.100
 
+VM_NAME="localhost"
 
 help() {
 
@@ -95,7 +96,7 @@ EOF
 }
 
 debug__dump() {
-    is_vm=$(expr "$(uname -n)" == "ebpf")
+    is_vm=$([[ "$(uname -n)" == "$VM_NAME" ]] && echo true || echo false)
     decode=""
     side=""
     type=""
@@ -223,7 +224,7 @@ EOF
 }
 
 debug__ping() {
-    is_vm=$([[ "$(uname -n)" == "ebpf" ]] && echo true || echo false)
+    is_vm=$([[ "$(uname -n)" == "$VM_NAME" ]] && echo true || echo false)
     reverse=false
     master=false
     target=""
@@ -825,7 +826,7 @@ test__advanced() {
 }
 
 test() {
-    is_vm=$([[ "$(uname -n)" == "ebpf" ]] && echo true || echo false)
+    is_vm=$([[ "$(uname -n)" == "$VM_NAME" ]] && echo true || echo false)
     if [[ "$is_vm" == true ]]; then
         echo "All test commands must be executed on the host."
         return 1

--- a/src/bc-pqp-ebpf-kernel.c
+++ b/src/bc-pqp-ebpf-kernel.c
@@ -88,22 +88,25 @@ int bypass_kernel_if_possible(struct xdp_md *ctx) {
     }
     __u64 next_hop_mac = *next_hop_mac_ptr;
     char new_dest[6] = {
-        ((next_hop_mac >> 0) & 0xff),  ((next_hop_mac >> 8) & 0xff),
-        ((next_hop_mac >> 16) & 0xff), ((next_hop_mac >> 24) & 0xff),
-        ((next_hop_mac >> 32) & 0xff), ((next_hop_mac >> 40) & 0xff),
+        (char)((next_hop_mac >> 0) & 0xff),
+        (char)((next_hop_mac >> 8) & 0xff),
+        (char)((next_hop_mac >> 16) & 0xff),
+        (char)((next_hop_mac >> 24) & 0xff),
+        (char)((next_hop_mac >> 32) & 0xff),
+        (char)((next_hop_mac >> 40) & 0xff),
     };
 
     __u32 egress_key = MAC_VM_EGRESS;
-    char *egress_mac_ptr = (char *)bpf_map_lookup_elem(&mac_map, &egress_key);
+    __u64 *egress_mac_ptr = (__u64 *)bpf_map_lookup_elem(&mac_map, &egress_key);
     if (egress_mac_ptr == NULL) {
         log("Could not find egress MAC address", 34);
         return XDP_PASS;
     }
     __u64 egress_mac = *egress_mac_ptr;
     char new_src[6] = {
-        ((egress_mac >> 0) & 0xff),  ((egress_mac >> 8) & 0xff),
-        ((egress_mac >> 16) & 0xff), ((egress_mac >> 24) & 0xff),
-        ((egress_mac >> 32) & 0xff), ((egress_mac >> 40) & 0xff),
+        (char)((egress_mac >> 0) & 0xff),  (char)((egress_mac >> 8) & 0xff),
+        (char)((egress_mac >> 16) & 0xff), (char)((egress_mac >> 24) & 0xff),
+        (char)((egress_mac >> 32) & 0xff), (char)((egress_mac >> 40) & 0xff),
     };
 
     __builtin_memcpy(eth_header->h_dest, new_dest, ETH_ALEN);

--- a/src/bc-pqp-ebpf-kernel.c
+++ b/src/bc-pqp-ebpf-kernel.c
@@ -11,15 +11,19 @@
 
 #define PARSING_ERROR -1
 
+#ifndef RX_QUEUES
 #define RX_QUEUES 4
+#endif
+
 #define PHANTOM_QUEUES 10
 
 #define MEBIBYTE (1 << 20)
 #define GIBIBYTE (1 << 30)
+#define TEBIBYTE (1 << 40)
 
 #define ONE_SECOND 1000000000L // 1s = 1e9 ns
 #define BURST_TIME 100000000L
-#define RATE MEBIBYTE // 1 MB/s
+#define RATE GIBIBYTE
 
 #define STRIP_HEADERS
 
@@ -34,6 +38,81 @@
     do {                                                                       \
     } while (0)
 #endif
+
+#define EGRESS_INTERFACE 3
+
+enum mac_index {
+    MAC_CLIENT,
+    MAC_VM_INGRESS,
+    MAC_VM_EGRESS,
+    MAC_SERVER,
+};
+
+#define MAC_ADDRESS_COUNT 4
+_Static_assert(MAC_SERVER < MAC_ADDRESS_COUNT,
+               "Need enough space for MAC addresses");
+
+struct {
+    __uint(type, BPF_MAP_TYPE_ARRAY);
+    __type(key, __u32);
+    __type(value, __u64);
+    __uint(max_entries, 4);
+    __uint(pinning, LIBBPF_PIN_BY_NAME);
+} mac_map SEC(".maps");
+
+// bypass kernel networking stack by rewriting the MAC address to eth1
+int bypass_kernel_if_possible(struct xdp_md *ctx) {
+    void *data = (void *)(long)ctx->data;
+    void *data_end = (void *)(long)ctx->data_end;
+    struct hdr_cursor nh;
+    nh.pos = data;
+
+    struct ethhdr *eth_header;
+    int eth_type = parse_ethhdr(&nh, data_end, &eth_header);
+    eth_type = bpf_ntohs(eth_type);
+
+    switch (eth_type) {
+    case ETH_P_IP:
+        break;
+    default:
+        log("We are passing the packet to the kernel.");
+        return XDP_PASS;
+    }
+
+    __u32 server_key = MAC_SERVER;
+    __u64 *next_hop_mac_ptr =
+        (__u64 *)bpf_map_lookup_elem(&mac_map, &server_key);
+    if (next_hop_mac_ptr == NULL) {
+        log("Could not find next hop MAC address", 36);
+        return XDP_PASS;
+    }
+    __u64 next_hop_mac = *next_hop_mac_ptr;
+    char new_dest[6] = {
+        ((next_hop_mac >> 0) & 0xff),  ((next_hop_mac >> 8) & 0xff),
+        ((next_hop_mac >> 16) & 0xff), ((next_hop_mac >> 24) & 0xff),
+        ((next_hop_mac >> 32) & 0xff), ((next_hop_mac >> 40) & 0xff),
+    };
+
+    __u32 egress_key = MAC_VM_EGRESS;
+    char *egress_mac_ptr = (char *)bpf_map_lookup_elem(&mac_map, &egress_key);
+    if (egress_mac_ptr == NULL) {
+        log("Could not find egress MAC address", 34);
+        return XDP_PASS;
+    }
+    __u64 egress_mac = *egress_mac_ptr;
+    char new_src[6] = {
+        ((egress_mac >> 0) & 0xff),  ((egress_mac >> 8) & 0xff),
+        ((egress_mac >> 16) & 0xff), ((egress_mac >> 24) & 0xff),
+        ((egress_mac >> 32) & 0xff), ((egress_mac >> 40) & 0xff),
+    };
+
+    __builtin_memcpy(eth_header->h_dest, new_dest, ETH_ALEN);
+    __builtin_memcpy(eth_header->h_source, new_src, ETH_ALEN);
+    log("Kernel Bypass: Redirecting packet %lx -> %lx", 45, egress_mac,
+        next_hop_mac);
+
+    return bpf_redirect(EGRESS_INTERFACE, 0);
+}
 
 struct phantom_queue {
     // how many bytes are currently in this queue
@@ -344,8 +423,7 @@ drop:
     log("We are dropping the packet.");
     return XDP_DROP;
 pass:
-    log("We are passing the packet to the kernel.");
-    return XDP_PASS;
+    return bypass_kernel_if_possible(ctx);
 }
 
 char _license[] SEC("license") = "GPL";


### PR DESCRIPTION
This PR implements bypassing of the kernel for IP packets (currently the only important for testing).
We achieve this by rewriting the source and destination MAC address of the packets.
To achieve this in our virtualized test setup, where MAC addresses are not fixed, we resolve the MAC addresses on program load and write them into a map, which we then access in eBPF at runtime.

This seems to not noticeably affect performance.
Unfortunately, it also makes loading slow, especially the first time.