### PR TITLE
Various cleanups

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ EBPF_SRC = bc-pqp-ebpf-kernel.c
 RX_QUEUES ?= 4
 PHANTOM_QUEUES ?= 10
 BURST_TIME ?= 10000000L
-RATE ?= GIBIBYTE
+RATE ?= GIBIBIT
 
 SRC_DIR = src
 BUILD_DIR = build

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ LLC = llc
 CLANG = clang
 
 C_FLAGS = -O2
-WARN_FLAGS = -Wall -Wno-unused-value -Wno-pointer-sign -Wno-compare-distinct-pointer-types -Wsign-compare -Wsign-conversion -Werror
+WARN_FLAGS = -Wall -Wno-unused-value -Wno-pointer-sign -Wno-compare-distinct-pointer-types -Wsign-compare -Wimplicit-fallthrough -Wsign-conversion -Werror
 
 EBPF_HDR = 
 

--- a/src/bc-pqp-ebpf-kernel.c
+++ b/src/bc-pqp-ebpf-kernel.c
@@ -160,14 +160,6 @@ struct {
     __uint(pinning, LIBBPF_PIN_BY_NAME);
 } xdp_general_map SEC(".maps");
 
-struct {
-    __uint(type, BPF_MAP_TYPE_ARRAY);
-    __type(key, __u32);
-    __type(value, __u64);
-    __uint(max_entries, PHANTOM_QUEUES + 1);
-    __uint(pinning, LIBBPF_PIN_BY_NAME);
-} classification_counts SEC(".maps");
-
 static __u64 calculate_drain(__u64 now, __u64 previous, __u64 rate) {
     // can be negative if we have a timing issue and someone who has started
     // after us already managed to write to the queue. In that case our drain
@@ -422,24 +414,6 @@ int bc_pqp_xdp(struct xdp_md* ctx) {
 
     __u32 classification, packet_size;
     classify_packet(ctx, &classification, &packet_size);
-    // sanity check for the loader
-    // todo this somehow only works with 8 as upper bound?
-    if (classification >= 0 && classification <= PHANTOM_QUEUES) {
-        __u64* value = (__u64*)bpf_map_lookup_elem(
-            &classification_counts, &classification
-        );
-        if (value != NULL) {
-            log("Classification successful: [%u] = %lu", classification,
-                *value);
-            __sync_fetch_and_add(value, 1);
-        } else {
-            log("Classification unsuccessful");
-            goto abort;
-        }
-    } else {
-        log("Aborting because classification is out of range");
-        goto abort;
-    }
 
     struct phantom_queue* queue = (struct phantom_queue*)bpf_map_lookup_elem(
         &xdp_general_map, &classification

--- a/src/bc-pqp-ebpf-kernel.c
+++ b/src/bc-pqp-ebpf-kernel.c
@@ -27,6 +27,10 @@
 #define GIBIBYTE (1 << 30)
 #define TEBIBYTE (1 << 40)
 
+#define MEBIBIT (MEBIBYTE >> 3)
+#define GIBIBIT (GIBIBYTE >> 3)
+#define TEBIBIT (TEBIBYTE >> 3)
+
 #define ONE_SECOND 1000000000L // 1s = 1e9 ns
 
 #ifndef BURST_TIME
@@ -34,7 +38,7 @@
 #endif
 
 #ifndef RATE
-#define RATE GIBIBYTE
+#define RATE GIBIBIT
 #endif
 
 #ifdef DEBUG

--- a/src/bc-pqp-ebpf-kernel.c
+++ b/src/bc-pqp-ebpf-kernel.c
@@ -156,7 +156,7 @@ struct {
     __uint(type, BPF_MAP_TYPE_ARRAY);
     __type(key, __u32);
     __type(value, struct phantom_queue);
-    __uint(max_entries, PHANTOM_QUEUES + 1);
+    __uint(max_entries, PHANTOM_QUEUES);
     __uint(pinning, LIBBPF_PIN_BY_NAME);
 } xdp_general_map SEC(".maps");
 
@@ -373,12 +373,19 @@ static void classify_packet(
                     break;
                 }
                 default: {
-                    log("Cannot classify packet because of unknown packet "
+                    log("Cannot classify packet because of unknown transport "
                         "protocol: %u",
                         ip_type);
                     goto default_error;
                 }
             }
+            break;
+        }
+        default: {
+            log("Cannot classify packet because of unknown internet "
+                "protocol: %u",
+                eth_type);
+            goto default_error;
         }
     }
     *phantom_queue = port % PHANTOM_QUEUES;
@@ -419,8 +426,8 @@ int bc_pqp_xdp(struct xdp_md* ctx) {
         &xdp_general_map, &classification
     );
     if (queue == NULL) {
-        log("Could not read element %u from map", classification);
-        goto abort;
+        log("Could not classify packet, forwarding to kernel");
+        goto kernel;
     } else {
         if (queue->capacity == 0) {
             // we are first, start timer and initialize capacity
@@ -452,6 +459,8 @@ drop:
     return XDP_DROP;
 pass:
     return bypass_kernel_if_possible(ctx);
+kernel:
+    return XDP_PASS;
 }
 
 char _license[] SEC("license") = "GPL";

--- a/src/bc-pqp-ebpf-kernel.c
+++ b/src/bc-pqp-ebpf-kernel.c
@@ -58,6 +58,8 @@
 #else
 #define CLASSIFY_BY source
 #endif
+// a poor-mans log_2, calculated by looking at the MSB
+#define ld(x) (64 - (__u32)__builtin_clzll((__u64)x))
 
 enum mac_index {
     MAC_CLIENT,
@@ -162,18 +164,22 @@ struct {
 
 static __u64 calculate_drain(__u64 now, __u64 previous, __u64 rate) {
     // can be negative if we have a timing issue and someone who has started
-    // after us already managed to write to the queue. In that case our drain
-    // was already included in their drain, i.e. we don't have to do anything
+    // after us already managed to write to the queue. In that case our
+    // drain was already included in their drain, i.e. we don't have to do
+    // anything
     __s64 timespan = (__s64)(now - previous);
     if (timespan < (__s64)0) {
         return 0;
     }
-    __s64 res = timespan * (__s64)rate;
-    if (res < (__s64)0) {
-        res = INT_MAX;
+
+    // we try detect overflows (in a performant fashion)
+    if (ld(rate) + ld(timespan) <= sizeof(__u64) * 8) {
+        return (rate * (__u64)timespan) / ONE_SECOND;
+    } else {
+        log("overflowing drain detected (timespan: %ld, rate: %lu)", timespan,
+            rate);
+        return (((__u64)timespan) / ONE_SECOND) * rate;
     }
-    // res is now unsigned again since 0 <= res <= MAX_INT
-    return (__u64)res / ONE_SECOND;
 }
 
 /**

--- a/src/bc-pqp-ebpf-kernel.c
+++ b/src/bc-pqp-ebpf-kernel.c
@@ -89,7 +89,7 @@ static __u32 bypass_kernel_if_possible(struct xdp_md* ctx) {
     nh.pos = data;
 
     struct ethhdr* eth_header;
-    __u32 eth_type = (__u32)parse_ethhdr(&nh, data_end, &eth_header);
+    __s32 eth_type = parse_ethhdr(&nh, data_end, &eth_header);
     eth_type = bpf_ntohs(eth_type);
 
     switch (eth_type) {

--- a/src/bc-pqp-ebpf-kernel.c
+++ b/src/bc-pqp-ebpf-kernel.c
@@ -333,7 +333,7 @@ static void classify_packet(
     nh.pos = data;
 
     struct ethhdr* eth;
-    __u32 eth_type = (__u32)parse_ethhdr(&nh, data_end, &eth);
+    __s32 eth_type = parse_ethhdr(&nh, data_end, &eth);
     eth_type = bpf_ntohs(eth_type);
 
     __u32 port = 0;

--- a/src/bc-pqp-ebpf-kernel.c
+++ b/src/bc-pqp-ebpf-kernel.c
@@ -82,14 +82,14 @@ struct {
 } mac_map SEC(".maps");
 
 // bypass kernel networking stack by rewriting the MAC address to eth1
-int bypass_kernel_if_possible(struct xdp_md* ctx) {
+static __u32 bypass_kernel_if_possible(struct xdp_md* ctx) {
     void* data = (void*)(long)ctx->data;
     void* data_end = (void*)(long)ctx->data_end;
     struct hdr_cursor nh;
     nh.pos = data;
 
     struct ethhdr* eth_header;
-    int eth_type = parse_ethhdr(&nh, data_end, &eth_header);
+    __u32 eth_type = (__u32)parse_ethhdr(&nh, data_end, &eth_header);
     eth_type = bpf_ntohs(eth_type);
 
     switch (eth_type) {
@@ -333,7 +333,7 @@ static void classify_packet(
     nh.pos = data;
 
     struct ethhdr* eth;
-    int eth_type = parse_ethhdr(&nh, data_end, &eth);
+    __u32 eth_type = (__u32)parse_ethhdr(&nh, data_end, &eth);
     eth_type = bpf_ntohs(eth_type);
 
     __u32 port = 0;
@@ -422,7 +422,7 @@ static __u32 initialize(struct phantom_queue* queue) {
 }
 
 SEC("xdp")
-int bc_pqp_xdp(struct xdp_md* ctx) {
+__u32 bc_pqp_xdp(struct xdp_md* ctx) {
     log("===== BC-PQP on rx-queue %u =====", ctx->rx_queue_index);
 
     __u32 classification, packet_size;


### PR DESCRIPTION
Included changes:
- remove unused `classification_counts` that is just burning CPU cycles
- don't touch packets that we can't classify
- better (and at least actually somewhat meaningful) overflow detection when calculating drain
- minor consistency improvements